### PR TITLE
Update ci to use golang 1.13 for distribution, this version supports …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
 
   distribute:
     docker:
-      - image: golang:1.12
+      - image: golang:1.13
     working_directory: /go/src/github.com/lrills/helm-unittest
     steps:
       - checkout


### PR DESCRIPTION
…go modules.