### PR TITLE
removed -s. Invalid option for sha256sum

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -120,7 +120,7 @@ installFile() {
       if type "shasum" >/dev/null 2>&1; then
         curl -s -L "$PROJECT_CHECKSUM" | grep "$DOWNLOAD_FILE" | shasum -a 256 -c -s
       elif type "sha256sum" >/dev/null 2>&1; then
-        curl -s -L "$PROJECT_CHECKSUM" | grep "$DOWNLOAD_FILE" | sha256sum -c -s
+        curl -s -L "$PROJECT_CHECKSUM" | grep "$DOWNLOAD_FILE" | sha256sum -c
       else
         echo No Checksum as there is no shasum or sha256sum found.
       fi
@@ -128,7 +128,7 @@ installFile() {
       if type "shasum" >/dev/null 2>&1; then
         wget -q -O - "$PROJECT_CHECKSUM" | grep "$DOWNLOAD_FILE" | shasum -a 256 -c -s
       elif type "sha256sum" >/dev/null 2>&1; then
-        wget -q -O - "$PROJECT_CHECKSUM" | grep "$DOWNLOAD_FILE" | sha256sum -c -s
+        wget -q -O - "$PROJECT_CHECKSUM" | grep "$DOWNLOAD_FILE" | sha256sum -c
       else
         echo No Checksum as there is no shasum or sha256sum found.
       fi


### PR DESCRIPTION
Hi, 

While installing the plugin to centos, checksum validation fails with the below error

<img width="512" alt="Screenshot 2020-10-15 at 14 22 50" src="https://user-images.githubusercontent.com/37596911/96122486-3e9cac00-0efa-11eb-9ea9-92d8351500b4.png">

The install binary sh file was updated to fix the issue.

I don't have a go environment setup, so unable to test the complete installation, but still tested the checksum validation part which was successful in Centos.

Thanks and incase the update the not correct, please help to fix the installation issue 
