### PR TITLE
fix failing install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are ready for writing tests, check the [DOCUMENT](./DOCUMENT.md) for the 
 ## Install
 
 ```
-$ helm plugin install https://github.com/quintush/helm-unittest
+$ helm plugin install https://github.com/quintush/helm-unittest.git
 ```
 
 It will install the latest version of binary into helm plugin directory.


### PR DESCRIPTION
Without the suffix `.git` the installation fails on MacOS.