### PR TITLE
Feature/values files as path parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 0.2.6 /
 ==================
-- Add support for list of templates on tests
-- Add support for failfast
-- Add support for strict validation of testsuites
+- Add support for list of templates on tests (credits to: @stevelipinski)
+- Add support for failfast (resolves #84)
+- Add support for values files in testsuite (resolves #91)
+- Add support for values files in path (resolves #92)
+- Add support for strict validation of testsuites (resolves #80, #94)
+- Fix contains assert validation, when count is used (resolves #98)
+- Fix small documentation corrections (credits to: @mik-laj, @Michael03, @SaffatHasan)
+- Update packages to lates version
 
 0.2.5 / 2020-11-17 
 ==================

--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -29,6 +29,7 @@ capabilities:
     - br.dev.local/v2
 chart:
   version: 1.0.0
+  appVersion: 1.0.0
 tests:
   - it: should test something
     ...
@@ -51,6 +52,7 @@ tests:
 
 - **chart**: *object, optional*. Define the `{{ .Chart }}` object.
   - **version**: *string, optional*. The semantic version of the chart, default to the version set in the Chart.
+  - **appVersion**: *string, optional*. The app-version of the chart, default to the app-version set in the Chart.
 
 - **tests**: *array of test job, required*. Where you define your test jobs to run, check [Test Job](#test-job).
 
@@ -83,6 +85,7 @@ tests:
         - custom.api/v1
     chart:
       version: 1.0.0
+      appVersion: 1.0.0
     asserts:
       - equal:
           path: metadata.name
@@ -112,6 +115,7 @@ tests:
 
 - **chart**: *object, optional*. Define the `{{ .Chart }}` object.
   - **version**: *string, optional*. The semantic version of the chart, default to the version set in the Chart.
+  - **appVersion**: *string, optional*. The app-version of the chart, default to the app-version set in the Chart.
 
 - **asserts**: *array of assertion, required*. The assertions to validate the rendered chart, check [Assertion](#assertion).
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ defined in test suite files.
 ```
       --color                  enforce printing colored output even stdout is not a tty. Set to false to disable color
       --strict                 strict parse the testsuites (default false)
-  -v, --values stringArray     glob paths of values files location, default no value files
+  -v, --values stringArray     absolute or glob paths of values files location, default no values files
   -f, --file stringArray       glob paths of test files location, default to tests\*_test.yaml (default [tests\*_test.yaml])
   -3, --helm3                  parse helm charts as helm3 charts (default false)
   -q, --failfast               direct quit testing, when a test is failed (default false)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ defined in test suite files.
 ```
       --color                  enforce printing colored output even stdout is not a tty. Set to false to disable color
       --strict                 strict parse the testsuites (default false)
+  -v, --values stringArray     glob paths of values files location, default no value files
   -f, --file stringArray       glob paths of test files location, default to tests\*_test.yaml (default [tests\*_test.yaml])
   -3, --helm3                  parse helm charts as helm3 charts (default false)
   -q, --failfast               direct quit testing, when a test is failed (default false)

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -122,7 +122,7 @@ func init() {
 
 	cmd.PersistentFlags().StringArrayVarP(
 		&testConfig.valuesFiles, "values", "v", []string{},
-		"glob paths of values files location, default no value files",
+		"absolute or glob paths of values files location, default no values files",
 	)
 
 	cmd.PersistentFlags().BoolVarP(

--- a/cmd/helm-unittest/helm_unittest.go
+++ b/cmd/helm-unittest/helm_unittest.go
@@ -20,6 +20,7 @@ type testOptions struct {
 	updateSnapshot bool
 	withSubChart   bool
 	testFiles      []string
+	valuesFiles    []string
 	outputFile     string
 	outputType     string
 }
@@ -57,7 +58,7 @@ Or specify the suite files glob path pattern:
 
 $ helm unittest -f 'my-tests/*.yaml' my-chart
 
-Check https://github.com/lrills/helm-unittest for more
+Check https://github.com/quintush/helm-unittest for more
 details about how to write tests.
 `,
 	Args: cobra.MinimumNArgs(1),
@@ -77,6 +78,7 @@ details about how to write tests.
 			Strict:         testConfig.useStrict,
 			Failfast:       testConfig.useFailfast,
 			TestFiles:      testConfig.testFiles,
+			ValuesFiles:    testConfig.valuesFiles,
 			OutputFile:     testConfig.outputFile,
 		}
 		var passed bool
@@ -116,6 +118,11 @@ func init() {
 	cmd.PersistentFlags().StringArrayVarP(
 		&testConfig.testFiles, "file", "f", []string{defaultFilePattern},
 		"glob paths of test files location, default to "+defaultFilePattern,
+	)
+
+	cmd.PersistentFlags().StringArrayVarP(
+		&testConfig.valuesFiles, "values", "v", []string{},
+		"glob paths of values files location, default no value files",
 	)
 
 	cmd.PersistentFlags().BoolVarP(

--- a/pkg/unittest/.snapshots/TestV2RunnerOkWithAbsoluteOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV2RunnerOkWithAbsoluteOverrideValuesPassedTests
@@ -1,0 +1,19 @@
+
+### Chart [ basic ] ../../test/data/v2/basic
+
+
+ PASS  Configmap mulit line Test	../../test/data/v2/basic/tests/configmap_test.yaml
+ PASS  Custom Resource Definition Test	../../test/data/v2/basic/tests/crd_test.yaml
+ PASS  test deployment	../../test/data/v2/basic/tests/deployment_test.yaml
+ PASS  test ingress	../../test/data/v2/basic/tests/ingress_test.yaml
+ PASS  test notes	../../test/data/v2/basic/tests/notes_test.yaml
+ PASS  test service	../../test/data/v2/basic/tests/service_test.yaml
+
+
+Charts:      1 passed, 1 total
+Test Suites: 6 passed, 6 total
+Tests:       14 passed, 14 total
+Snapshot:    4 passed, 4 total
+Time:        XX.XXXms
+
+

--- a/pkg/unittest/.snapshots/TestV2RunnerOkWithOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV2RunnerOkWithOverrideValuesPassedTests
@@ -1,0 +1,19 @@
+
+### Chart [ basic ] ../../test/data/v2/basic
+
+
+ PASS  Configmap mulit line Test	../../test/data/v2/basic/tests/configmap_test.yaml
+ PASS  Custom Resource Definition Test	../../test/data/v2/basic/tests/crd_test.yaml
+ PASS  test deployment	../../test/data/v2/basic/tests/deployment_test.yaml
+ PASS  test ingress	../../test/data/v2/basic/tests/ingress_test.yaml
+ PASS  test notes	../../test/data/v2/basic/tests/notes_test.yaml
+ PASS  test service	../../test/data/v2/basic/tests/service_test.yaml
+
+
+Charts:      1 passed, 1 total
+Test Suites: 6 passed, 6 total
+Tests:       14 passed, 14 total
+Snapshot:    4 passed, 4 total
+Time:        XX.XXXms
+
+

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests
@@ -1,0 +1,19 @@
+
+### Chart [ basic ] ../../test/data/v2/basic
+
+
+ PASS  Configmap mulit line Test	../../test/data/v2/basic/tests/configmap_test.yaml
+ PASS  Custom Resource Definition Test	../../test/data/v2/basic/tests/crd_test.yaml
+ PASS  test deployment	../../test/data/v2/basic/tests/deployment_test.yaml
+ PASS  test ingress	../../test/data/v2/basic/tests/ingress_test.yaml
+ PASS  test notes	../../test/data/v2/basic/tests/notes_test.yaml
+ PASS  test service	../../test/data/v2/basic/tests/service_test.yaml
+
+
+Charts:      1 passed, 1 total
+Test Suites: 6 passed, 6 total
+Tests:       14 passed, 14 total
+Snapshot:    4 passed, 4 total
+Time:        XX.XXXms
+
+

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithOverrideValuesPassedTests
@@ -1,0 +1,19 @@
+
+### Chart [ basic ] ../../test/data/v2/basic
+
+
+ PASS  Configmap mulit line Test	../../test/data/v2/basic/tests/configmap_test.yaml
+ PASS  Custom Resource Definition Test	../../test/data/v2/basic/tests/crd_test.yaml
+ PASS  test deployment	../../test/data/v2/basic/tests/deployment_test.yaml
+ PASS  test ingress	../../test/data/v2/basic/tests/ingress_test.yaml
+ PASS  test notes	../../test/data/v2/basic/tests/notes_test.yaml
+ PASS  test service	../../test/data/v2/basic/tests/service_test.yaml
+
+
+Charts:      1 passed, 1 total
+Test Suites: 6 passed, 6 total
+Tests:       14 passed, 14 total
+Snapshot:    4 passed, 4 total
+Time:        XX.XXXms
+
+

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -20,19 +20,21 @@ import (
 func getFiles(chartPath string, filePatterns []string, setAbsolute bool) ([]string, error) {
 	filesSet := make([]string, 0)
 	for _, pattern := range filePatterns {
-		files, err := filepath.Glob(filepath.Join(chartPath, pattern))
-		if err != nil {
-			return nil, err
-		}
-		if setAbsolute {
-			for _, file := range files {
-				if !filepath.IsAbs(file) {
+		if !filepath.IsAbs(pattern) {
+			files, err := filepath.Glob(filepath.Join(chartPath, pattern))
+			if err != nil {
+				return nil, err
+			}
+			if setAbsolute {
+				for _, file := range files {
 					file, _ = filepath.Abs(file)
+					filesSet = append(filesSet, file)
 				}
-				filesSet = append(filesSet, file)
+			} else {
+				filesSet = append(filesSet, files...)
 			}
 		} else {
-			filesSet = append(filesSet, files...)
+			filesSet = append(filesSet, pattern)
 		}
 	}
 

--- a/pkg/unittest/test_runner.go
+++ b/pkg/unittest/test_runner.go
@@ -17,6 +17,28 @@ import (
 	v2chart "k8s.io/helm/pkg/proto/hapi/chart"
 )
 
+func getFiles(chartPath string, filePatterns []string, setAbsolute bool) ([]string, error) {
+	filesSet := make([]string, 0)
+	for _, pattern := range filePatterns {
+		files, err := filepath.Glob(filepath.Join(chartPath, pattern))
+		if err != nil {
+			return nil, err
+		}
+		if setAbsolute {
+			for _, file := range files {
+				if !filepath.IsAbs(file) {
+					file, _ = filepath.Abs(file)
+				}
+				filesSet = append(filesSet, file)
+			}
+		} else {
+			filesSet = append(filesSet, files...)
+		}
+	}
+
+	return filesSet, nil
+}
+
 // testUnitCounting stores counting numbers of test unit status
 type testUnitCounting struct {
 	passed  uint
@@ -63,6 +85,7 @@ type TestRunner struct {
 	Strict           bool
 	Failfast         bool
 	TestFiles        []string
+	ValuesFiles      []string
 	OutputFile       string
 	suiteCounting    testUnitCountingWithSnapshotFailed
 	testCounting     testUnitCounting
@@ -156,20 +179,19 @@ func (tr *TestRunner) RunV3(ChartPaths []string) bool {
 }
 
 func (tr *TestRunner) getTestSuites(chartPath, chartRoute string) ([]*TestSuite, error) {
-	filesSet := map[string]bool{}
-	for _, pattern := range tr.TestFiles {
-		files, err := filepath.Glob(filepath.Join(chartPath, pattern))
-		if err != nil {
-			return nil, err
-		}
-		for _, file := range files {
-			filesSet[file] = true
-		}
+	testFilesSet, terr := getFiles(chartPath, tr.TestFiles, false)
+	if terr != nil {
+		return nil, terr
 	}
 
-	resultSuites := make([]*TestSuite, 0, len(filesSet))
-	for file := range filesSet {
-		suite, err := ParseTestSuiteFile(file, chartRoute, tr.Strict)
+	valuesFilesSet, verr := getFiles("", tr.ValuesFiles, true)
+	if verr != nil {
+		return nil, verr
+	}
+
+	resultSuites := make([]*TestSuite, 0, len(testFilesSet))
+	for _, file := range testFilesSet {
+		suite, err := ParseTestSuiteFile(file, chartRoute, tr.Strict, valuesFilesSet)
 		if err != nil {
 			tr.handleSuiteResult(&results.TestSuiteResult{
 				FilePath:  file,

--- a/pkg/unittest/test_runner_test.go
+++ b/pkg/unittest/test_runner_test.go
@@ -91,6 +91,18 @@ func TestV2RunnerOkWithPassedTests(t *testing.T) {
 	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
 }
 
+func TestV2RunnerOkWithOverrideValuesPassedTests(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:     printer.NewPrinter(buffer, nil),
+		TestFiles:   []string{testTestFiles},
+		ValuesFiles: []string{testValuesFiles},
+	}
+	passed := runner.RunV2([]string{testV2BasicChart})
+	assert.True(t, passed, buffer.String())
+	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
+}
+
 func TestV2RunnerOkWithFailedTests(t *testing.T) {
 	buffer := new(bytes.Buffer)
 	runner := TestRunner{
@@ -167,6 +179,18 @@ func TestV3RunnerOkWithPassedTests(t *testing.T) {
 		TestFiles: []string{testTestFiles},
 	}
 	passed := runner.RunV3([]string{testV3BasicChart})
+	assert.True(t, passed, buffer.String())
+	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
+}
+
+func TestV3RunnerOkWithOverrideValuesPassedTests(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:     printer.NewPrinter(buffer, nil),
+		TestFiles:   []string{testTestFiles},
+		ValuesFiles: []string{testValuesFiles},
+	}
+	passed := runner.RunV3([]string{testV2BasicChart})
 	assert.True(t, passed, buffer.String())
 	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
 }

--- a/pkg/unittest/test_runner_test.go
+++ b/pkg/unittest/test_runner_test.go
@@ -2,6 +2,7 @@ package unittest_test
 
 import (
 	"bytes"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -93,10 +94,11 @@ func TestV2RunnerOkWithPassedTests(t *testing.T) {
 
 func TestV2RunnerOkWithOverrideValuesPassedTests(t *testing.T) {
 	buffer := new(bytes.Buffer)
+	fullPath, _ := filepath.Abs(testValuesFiles)
 	runner := TestRunner{
 		Printer:     printer.NewPrinter(buffer, nil),
 		TestFiles:   []string{testTestFiles},
-		ValuesFiles: []string{testValuesFiles},
+		ValuesFiles: []string{fullPath},
 	}
 	passed := runner.RunV2([]string{testV2BasicChart})
 	assert.True(t, passed, buffer.String())
@@ -185,10 +187,11 @@ func TestV3RunnerOkWithPassedTests(t *testing.T) {
 
 func TestV3RunnerOkWithOverrideValuesPassedTests(t *testing.T) {
 	buffer := new(bytes.Buffer)
+	fullPath, _ := filepath.Abs(testValuesFiles)
 	runner := TestRunner{
 		Printer:     printer.NewPrinter(buffer, nil),
 		TestFiles:   []string{testTestFiles},
-		ValuesFiles: []string{testValuesFiles},
+		ValuesFiles: []string{fullPath},
 	}
 	passed := runner.RunV3([]string{testV2BasicChart})
 	assert.True(t, passed, buffer.String())

--- a/pkg/unittest/test_runner_test.go
+++ b/pkg/unittest/test_runner_test.go
@@ -94,6 +94,18 @@ func TestV2RunnerOkWithPassedTests(t *testing.T) {
 
 func TestV2RunnerOkWithOverrideValuesPassedTests(t *testing.T) {
 	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:     printer.NewPrinter(buffer, nil),
+		TestFiles:   []string{testTestFiles},
+		ValuesFiles: []string{testValuesFiles},
+	}
+	passed := runner.RunV2([]string{testV2BasicChart})
+	assert.True(t, passed, buffer.String())
+	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
+}
+
+func TestV2RunnerOkWithAbsoluteOverrideValuesPassedTests(t *testing.T) {
+	buffer := new(bytes.Buffer)
 	fullPath, _ := filepath.Abs(testValuesFiles)
 	runner := TestRunner{
 		Printer:     printer.NewPrinter(buffer, nil),
@@ -186,6 +198,18 @@ func TestV3RunnerOkWithPassedTests(t *testing.T) {
 }
 
 func TestV3RunnerOkWithOverrideValuesPassedTests(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	runner := TestRunner{
+		Printer:     printer.NewPrinter(buffer, nil),
+		TestFiles:   []string{testTestFiles},
+		ValuesFiles: []string{testValuesFiles},
+	}
+	passed := runner.RunV3([]string{testV2BasicChart})
+	assert.True(t, passed, buffer.String())
+	cupaloy.SnapshotT(t, makeOutputSnapshotable(buffer.String())...)
+}
+
+func TestV3RunnerOkWithAbsoluteOverrideValuesPassedTests(t *testing.T) {
 	buffer := new(bytes.Buffer)
 	fullPath, _ := filepath.Abs(testValuesFiles)
 	runner := TestRunner{

--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ParseTestSuiteFile parse a suite file at path and returns TestSuite
-func ParseTestSuiteFile(suiteFilePath, chartRoute string, strict bool) (*TestSuite, error) {
+func ParseTestSuiteFile(suiteFilePath, chartRoute string, strict bool, valueFilesSet []string) (*TestSuite, error) {
 	suite := TestSuite{chartRoute: chartRoute}
 	content, err := ioutil.ReadFile(suiteFilePath)
 	if err != nil {
@@ -36,6 +36,9 @@ func ParseTestSuiteFile(suiteFilePath, chartRoute string, strict bool) (*TestSui
 			return &suite, err
 		}
 	}
+
+	// Append the valuesfiles from command to the testsuites.
+	suite.Values = append(suite.Values, valueFilesSet...)
 
 	return &suite, nil
 }

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -19,7 +19,7 @@ import (
 // Most used test files
 const testSuiteTests string = "_suite_tests"
 
-const testValuesFiles = "../../test/data/resources_values.yaml"
+const testValuesFiles = "../../test/data/services_values.yaml"
 const testTestFiles string = "tests/*_test.yaml"
 const testTestFailedFiles string = "tests_failed/*_test.yaml"
 

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -19,6 +19,7 @@ import (
 // Most used test files
 const testSuiteTests string = "_suite_tests"
 
+const testValuesFiles = "../../test/data/resources_values.yaml"
 const testTestFiles string = "tests/*_test.yaml"
 const testTestFailedFiles string = "tests_failed/*_test.yaml"
 
@@ -66,7 +67,7 @@ func validateTestResultAndSnapshots(
 
 func TestV2ParseTestSuiteUnstrictFileOk(t *testing.T) {
 	a := assert.New(t)
-	suite, err := ParseTestSuiteFile("../../test/data/v2/invalidbasic/tests/deployment_test.yaml", "basic", false)
+	suite, err := ParseTestSuiteFile("../../test/data/v2/invalidbasic/tests/deployment_test.yaml", "basic", false, []string{})
 
 	a.Nil(err)
 	a.Equal("test deployment", suite.Name)
@@ -76,7 +77,7 @@ func TestV2ParseTestSuiteUnstrictFileOk(t *testing.T) {
 
 func TestV2ParseTestSuiteFileOk(t *testing.T) {
 	a := assert.New(t)
-	suite, err := ParseTestSuiteFile("../../test/data/v2/basic/tests/deployment_test.yaml", "basic", true)
+	suite, err := ParseTestSuiteFile("../../test/data/v2/basic/tests/deployment_test.yaml", "basic", true, []string{})
 
 	a.Nil(err)
 	a.Equal("test deployment", suite.Name)
@@ -84,9 +85,20 @@ func TestV2ParseTestSuiteFileOk(t *testing.T) {
 	a.Equal("should pass all kinds of assertion", suite.Tests[0].Name)
 }
 
+func TestV2ParseTestSuiteFileWithOverrideValuesOk(t *testing.T) {
+	a := assert.New(t)
+	suite, err := ParseTestSuiteFile("../../test/data/v2/basic/tests/deployment_test.yaml", "basic", true, []string{testValuesFiles})
+
+	a.Nil(err)
+	a.Equal("test deployment", suite.Name)
+	a.Equal([]string{"configmap.yaml", "deployment.yaml"}, suite.Templates)
+	a.Equal("should pass all kinds of assertion", suite.Tests[0].Name)
+	a.Equal(2, len(suite.Values)) // Expect images and additional_values.yaml
+}
+
 func TestV2ParseTestSuiteFileInSubfolderOk(t *testing.T) {
 	a := assert.New(t)
-	suite, err := ParseTestSuiteFile("../../test/data/v2/with-subfolder/tests/service_test.yaml", "with-subfolder", true)
+	suite, err := ParseTestSuiteFile("../../test/data/v2/with-subfolder/tests/service_test.yaml", "with-subfolder", true, []string{})
 
 	a.Nil(err)
 	a.Equal("test service", suite.Name)
@@ -321,7 +333,7 @@ tests:
 
 func TestV3ParseTestSuiteUnstrictFileOk(t *testing.T) {
 	a := assert.New(t)
-	suite, err := ParseTestSuiteFile("../../test/data/v3/invalidbasic/tests/deployment_test.yaml", "basic", false)
+	suite, err := ParseTestSuiteFile("../../test/data/v3/invalidbasic/tests/deployment_test.yaml", "basic", false, []string{})
 
 	a.Nil(err)
 	a.Equal("test deployment", suite.Name)
@@ -331,12 +343,23 @@ func TestV3ParseTestSuiteUnstrictFileOk(t *testing.T) {
 
 func TestV3ParseTestSuiteFileOk(t *testing.T) {
 	a := assert.New(t)
-	suite, err := ParseTestSuiteFile("../../test/data/v3/basic/tests/deployment_test.yaml", "basic", true)
+	suite, err := ParseTestSuiteFile("../../test/data/v3/basic/tests/deployment_test.yaml", "basic", true, []string{})
 
 	a.Nil(err)
 	a.Equal(suite.Name, "test deployment")
 	a.Equal(suite.Templates, []string{"configmap.yaml", "deployment.yaml"})
 	a.Equal(suite.Tests[0].Name, "should pass all kinds of assertion")
+}
+
+func TestV3ParseTestSuiteFileWithOverrideValuesOk(t *testing.T) {
+	a := assert.New(t)
+	suite, err := ParseTestSuiteFile("../../test/data/v3/basic/tests/deployment_test.yaml", "basic", true, []string{testValuesFiles})
+
+	a.Nil(err)
+	a.Equal("test deployment", suite.Name)
+	a.Equal([]string{"configmap.yaml", "deployment.yaml"}, suite.Templates)
+	a.Equal("should pass all kinds of assertion", suite.Tests[0].Name)
+	a.Equal(2, len(suite.Values)) // Expect images and additional_values.yaml
 }
 
 func TestV3RunSuiteWithMultipleTemplatesWhenPass(t *testing.T) {

--- a/test/data/services_values.yaml
+++ b/test/data/services_values.yaml
@@ -1,0 +1,3 @@
+
+service:
+  type: NodePort

--- a/test/data/v2/basic/tests/service_test.yaml
+++ b/test/data/v2/basic/tests/service_test.yaml
@@ -5,6 +5,9 @@ tests:
   - it: should pass
     release:
       name: my-release
+    set:
+      service:
+        type: ClusterIP
     asserts:
       - contains:
           path: spec.ports
@@ -21,7 +24,7 @@ tests:
           value:
             app: basic
             release: my-release
-
+      
   - it: should render right if values given
     set:
       service:

--- a/test/data/v3/basic/tests/service_test.yaml
+++ b/test/data/v3/basic/tests/service_test.yaml
@@ -5,6 +5,9 @@ tests:
   - it: should pass
     release:
       name: my-release
+    set:
+      service:
+        type: ClusterIP
     asserts:
       - contains:
           path: spec.ports
@@ -21,7 +24,7 @@ tests:
           value:
             app: basic
             release: my-release
-
+      
   - it: should render right if values given
     set:
       service:


### PR DESCRIPTION
Make values files to be passed as parameters during the unittests.
Make it possible to use absolute paths or patterns for globs.