### PR TITLE
Allow plugin install on shared machine

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -155,6 +155,7 @@ installFile() {
   echo "Preparing to install into ${HELM_PLUGIN_PATH}"
   # Use * to also copy the file with the exe suffix on Windows
   cp "$HELM_TMP_BIN"* "$HELM_PLUGIN_PATH"
+  rm -r "$HELM_TMP"
   rm -r "$PLUGIN_TMP_FOLDER"
   echo "$PROJECT_NAME installed into $HELM_PLUGIN_PATH"
 }


### PR DESCRIPTION
Trying to install the plugin from more than one user on the same machine
fails when it is unpacking the tar.  The error looks like this:

```
[ktest@k8s-rhel7-01 ~]$ helm plugin install https://github.com/quintush/helm-unittest
Support linux-amd64
Retrieving https://api.github.com/repos/quintush/helm-unittest/releases/tags/v0.2.6
Downloading https://github.com/quintush/helm-unittest/releases/download/v0.2.6/helm-unittest-linux-amd64-0.2.6.tgz to location /tmp/_dist/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   643  100   643    0     0   2485      0 --:--:-- --:--:-- --:--:--  2492
100 17.8M  100 17.8M    0     0  23.2M      0 --:--:-- --:--:-- --:--:-- 23.2M
Validating Checksum.
tar: untt: Cannot open: File exists
tar: README.md: Cannot open: File exists
tar: LICENSE: Cannot open: File exists
tar: plugin.yaml: Cannot open: File exists
tar: Exiting with failure status due to previous errors
Failed to install helm-unittest
For support, go to https://github.com/kubernetes/helm
Error: plugin install hook for "unittest" exited with error
```

The root of the problem is that a temporary dir is not cleand up.  The fix I
applied was to remove this temp dir.