### PR TITLE
Clone chart.Metadata.Dependencies between test job executions

### DIFF
--- a/pkg/unittest/test_suite.go
+++ b/pkg/unittest/test_suite.go
@@ -234,7 +234,7 @@ func (s *TestSuite) runV3TestJobs(
 
 		chart.SetDependencies(dependenciesBackup...)
 		chart.Values = valuesBackup
-		chart.Metadata.Dependencies = metadataDependenciesBackup
+		chart.Metadata.Dependencies = cloneDependencies(metadataDependenciesBackup)
 
 		if !suitePass && failfast {
 			break


### PR DESCRIPTION
Fixes #115

After a test job executes, chart.Metadata.Dependencies.ImportValues type is changed from <map[string]interface {}> to <map[string]string>, which breaks the next job execution, as helm simply ignores ImportValues when type is <map[string]string>.

Issue only happens on the 3rd test job execution, because:
* 1st job uses original chart.Metadata.
* 2nd job uses cloned chart.Metadata (which become corrupted)

I have no idea what causes the type to change, I haven't seen any explicit manipulation of ImportValues  in helm source code.