### PR TITLE
Documenting `jq`-like path selection syntax

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -149,6 +149,14 @@ The assertion is defined with the assertion type as the key and its parameters a
 
 - **documentIndex**: *int, optional*. The index of rendered documents (divided by `---`) to be asserted, default to -1, which will assert all documents. Generally you can ignored this field if the template file render only one document.
 
+Map keys in `path` containing periods (`.`) are supported with the use of a `jq`-like syntax:
+
+```yaml
+- equal:
+    path: metadata.annotations.[kubernetes.io/ingress.class]
+    value: nginx
+```
+
 ### Assertion Types
 
 Available assertion types are listed below:


### PR DESCRIPTION
Documenting my understanding of https://github.com/quintush/helm-unittest/pull/8. Originally in https://github.com/lrills/helm-unittest/pull/86 I found that backslashes worked, but this seems cleaner.
