### PR TITLE
Pre-process rendered data before comparison.

### DIFF
--- a/pkg/unittest/validators/equal_validator.go
+++ b/pkg/unittest/validators/equal_validator.go
@@ -1,7 +1,9 @@
 package validators
 
 import (
+        "fmt"
 	"reflect"
+        "regexp"
 
 	"github.com/lrills/helm-unittest/internal/common"
 	"github.com/lrills/helm-unittest/pkg/unittest/valueutils"
@@ -53,6 +55,14 @@ func (a EqualValidator) Validate(context *ValidateContext) (bool, []string) {
 			errorMessage := splitInfof(errorFormat, idx, err.Error())
 			validateErrors = append(validateErrors, errorMessage...)
 			continue
+		}
+
+
+		_, ok := actual.(string)
+		if ok {
+			re := regexp.MustCompile(`(?m)[ ]+\n`)
+			substitution := "\n"
+			actual = re.ReplaceAllString(fmt.Sprintf("%v", actual), substitution)
 		}
 
 		if reflect.DeepEqual(a.Value, actual) == context.Negative {


### PR DESCRIPTION
For gopkg.in/yaml.v2, if there are spaces before break, it will take all input as plain string even special characters in yaml.

For example, following string will be treated as plain string because of type: \"slowpath\"      \n.
"dpdk-host-bind: \"true\"\niface-info:\n  eth0:\n    role: \"internal\"\n    type:
              \"slowpath\"\n  internal:\n    role: \"internal\"\n    **type: \"slowpath\"      \n**
              \ tracing:\n    mtu: 1500\n    role: \"external\"\n    type: \"slowpath\"\nvlan-info:
              \     \n  tracing:\n    - vlanId: 1916\n      vlanName: \"tracingvlan\"\n      ipv6RangeStart:
              \"2a00:8a00:8000:136:10:57:218:8f/122\"\n      ipv6RangeEnd: \"2a00:8a00:8000:136:10:57:218:8f/122\"\n
              \     ipv6Subnet: \"2a00:8a00:8000:136:10:57:217:1a/128\"\n      ipv6Role:\n      -
              \"Tracing\"\nip-role:\n  internal:\n    ipv6:\n      - \"internal\""
