### PR TITLE
feature: add `containsDocument` assertion

### DIFF
--- a/pkg/unittest/assertion.go
+++ b/pkg/unittest/assertion.go
@@ -184,4 +184,5 @@ var assertTypeMapping = map[string]assertTypeDef{
 	"isNotSubset":       {reflect.TypeOf(validators.IsSubsetValidator{}), true, true},
 	"failedTemplate":    {reflect.TypeOf(validators.FailedTemplateValidator{}), false, false},
 	"notFailedTemplate": {reflect.TypeOf(validators.FailedTemplateValidator{}), true, true},
+	"containsDocument":  {reflect.TypeOf(validators.ContainsDocumentValidator{}), false, true},
 }

--- a/pkg/unittest/validators/contains_document_validator.go
+++ b/pkg/unittest/validators/contains_document_validator.go
@@ -1,0 +1,82 @@
+package validators
+
+import (
+	"fmt"
+
+	"github.com/lrills/helm-unittest/pkg/unittest/valueutils"
+)
+
+// IsSubsetValidator validate whether value of Path contains Content
+type ContainsDocumentValidator struct {
+	Kind       string
+	APIVersion string
+	Name       string
+	Namespace  string
+}
+
+func (v ContainsDocumentValidator) failInfo(actual interface{}, index int, not bool) []string {
+	return splitInfof(
+		setFailFormat(not, false, false, false, " to contain document"),
+		index,
+		fmt.Sprintf("Kind = %s, apiVersion = %s", v.Kind, v.APIVersion),
+	)
+}
+
+// Validate implement Validatable
+func (v ContainsDocumentValidator) Validate(context *ValidateContext) (bool, []string) {
+	manifests, err := context.getManifests()
+	if err != nil {
+		return false, splitInfof(errorFormat, -1, err.Error())
+	}
+
+	validateSuccess := false
+	validateErrors := make([]string, 0)
+
+	fmt.Printf("%+v\n", v)
+	for _, manifest := range manifests {
+		if kind, ok := manifest["kind"].(string); (ok && kind == v.Kind) == context.Negative {
+			// if no match, move onto next document
+			continue
+		}
+
+		if api, ok := manifest["apiVersion"].(string); (ok && api == v.APIVersion) == context.Negative {
+			// if no match, move onto next document
+			continue
+		}
+
+		if v.Name != "" {
+			actual, err := valueutils.GetValueOfSetPath(manifest, "metadata.name")
+			if err != nil {
+				// fail on not found match
+				continue
+			}
+
+			if (actual == v.Name) == context.Negative {
+				continue
+			}
+		}
+
+		if v.Namespace != "" {
+			actual, err := valueutils.GetValueOfSetPath(manifest, "metadata.namespace")
+			if err != nil {
+				// fail on not found match
+				continue
+			}
+
+			if (actual == v.Namespace) == context.Negative {
+				continue
+			}
+		}
+
+		// if we get here the above have held so it is a match
+		validateSuccess = true
+		break
+	}
+	if !validateSuccess {
+		errorMesasge := v.failInfo(v.Kind, 0, context.Negative)
+		validateErrors = append(validateErrors, errorMesasge...)
+	}
+	validateSuccess = determineSuccess(1, validateSuccess, true)
+
+	return validateSuccess, validateErrors
+}

--- a/pkg/unittest/validators/contains_document_validator_test.go
+++ b/pkg/unittest/validators/contains_document_validator_test.go
@@ -1,0 +1,135 @@
+package validators_test
+
+import (
+	"testing"
+
+	"github.com/lrills/helm-unittest/internal/common"
+	. "github.com/lrills/helm-unittest/pkg/unittest/validators"
+	"github.com/stretchr/testify/assert"
+)
+
+var docToTestContainsDocument1 = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: foo
+  namespace: bar
+`
+
+var docToTestContainsDocument2 = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: bar
+  namespace: foo
+`
+
+func TestContainsDocumentValidatorWhenOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"bar",
+		"foo",
+	}
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: -1,
+		Docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+			makeManifest(docToTestContainsDocument2)},
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
+func TestContainsDocumentValidatorIndexWhenOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"bar",
+		"foo",
+	}
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: 1,
+		Docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+			makeManifest(docToTestContainsDocument2)},
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
+func TestContainsDocumentValidatorNoNameWhenOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"",
+		"foo",
+	}
+
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: -1,
+		Docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+			makeManifest(docToTestContainsDocument2)},
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
+func TestContainsDocumentValidatorNoNamespaceWhenOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"foo",
+		"",
+	}
+
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: -1,
+		Docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+			makeManifest(docToTestContainsDocument2)},
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
+func TestContainsDocumentValidatorNoNameNamespaceWhenOk(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Service",
+		"v1",
+		"",
+		"",
+	}
+
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: -1,
+		Docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+			makeManifest(docToTestContainsDocument2)},
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
+func TestContainsDocumentValidatorWhenFail(t *testing.T) {
+	validator := ContainsDocumentValidator{
+		"Deployment",
+		"apps/v1",
+		"foo",
+		"bar",
+	}
+
+	pass, diff := validator.Validate(&ValidateContext{
+		Index: -1,
+		Docs: []common.K8sManifest{makeManifest(docToTestContainsDocument1),
+			makeManifest(docToTestContainsDocument2)},
+	})
+
+	assert.False(t, pass)
+	assert.Equal(t, []string{
+		"DocumentIndex:\t0",
+		"Expected to contain document:",
+		"\tKind = Deployment, apiVersion = apps/v1",
+	}, diff)
+}


### PR DESCRIPTION
I have found it convenient to assert whether a document (based on Kind, APIVersion, Name - optional, Namespace - optional) is present. 

Example:

```
suite: deployment
templates:
  - deployment.yaml

tests:
- it: should contain deployment object
  asserts:
  - containsDocument:
      kind: Deployment
      apiVersion: apps/v1
      name: foo
      namespace: bar

```

Both `name` and `namespace` are optional in which it will base decision off just `kind` and `apiVersion`. 