### PR TITLE
Remove additional spaces for better multiline support

### DIFF
--- a/pkg/unittest/validators/common.go
+++ b/pkg/unittest/validators/common.go
@@ -3,6 +3,7 @@ package validators
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/lrills/helm-unittest/internal/common"
@@ -113,11 +114,13 @@ func diff(expected string, actual string) string {
 	return diff
 }
 
-// uniform the content with correct line-endings
+// uniform the content without invalid characters and correct line-endings
 func uniformContent(content interface{}) string {
-	// All decoded content uses LF
+	// For multilines, remove spaces before newlines
+	// And ensure all decoded content uses LF
+	regex := regexp.MustCompile(`(?m)[ ]+\r?\n`)
 	actual := fmt.Sprintf("%v", content)
-	return strings.ReplaceAll(actual, "\r\n", "\n")
+	return regex.ReplaceAllString(actual, "\n")
 }
 
 // Validate a subset, which are used for SubsetValidator and Contains (when Any option is used)

--- a/pkg/unittest/validators/equal_validator.go
+++ b/pkg/unittest/validators/equal_validator.go
@@ -55,6 +55,11 @@ func (a EqualValidator) Validate(context *ValidateContext) (bool, []string) {
 			continue
 		}
 
+		_, ok := actual.(string)
+		if ok {
+			actual = uniformContent(actual)
+		}
+
 		if reflect.DeepEqual(a.Value, actual) == context.Negative {
 			validateSuccess = false
 			errorMessage := a.failInfo(actual, idx, context.Negative)

--- a/pkg/unittest/validators/equal_validator_test.go
+++ b/pkg/unittest/validators/equal_validator_test.go
@@ -12,11 +12,26 @@ var docToTestEqual = `
 a:
   b:
     - c: 123
+  e: |
+    Line1 
+    Line2
 `
 
 func TestEqualValidatorWhenOk(t *testing.T) {
 	manifest := makeManifest(docToTestEqual)
 	validator := EqualValidator{"a.b[0].c", 123}
+
+	pass, diff := validator.Validate(&ValidateContext{
+		Docs: []common.K8sManifest{manifest},
+	})
+
+	assert.True(t, pass)
+	assert.Equal(t, []string{}, diff)
+}
+
+func TestEqualValidatorMultiLineWhenOk(t *testing.T) {
+	manifest := makeManifest(docToTestEqual)
+	validator := EqualValidator{"a.e", "Line1\nLine2\n"}
 
 	pass, diff := validator.Validate(&ValidateContext{
 		Docs: []common.K8sManifest{manifest},


### PR DESCRIPTION
Remove additional spaces for better multiline support
Centralize the content replacement for all possible multiline assertions