### PR TITLE
Helm v3: templating error parsing failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ untt.exe
 _dist
 
 .DS_Store
+
+.idea

--- a/pkg/unittest/.snapshots/TestV3RunJobWithFailingTempalte
+++ b/pkg/unittest/.snapshots/TestV3RunJobWithFailingTempalte
@@ -1,0 +1,18 @@
+(*results.TestJobResult)({
+  DisplayName: (string) (len=11) "should work",
+  Index: (int) 0,
+  Passed: (bool) true,
+  ExecError: (error) <nil>,
+  AssertsResult: ([]*results.AssertionResult) (len=1) {
+    (*results.AssertionResult)({
+      Index: (int) 0,
+      FailInfo: ([]string) {
+      },
+      Passed: (bool) true,
+      AssertType: (string) (len=14) "failedTemplate",
+      Not: (bool) false,
+      CustomInfo: (string) ""
+    })
+  },
+  Duration: (time.Duration) 0s
+})

--- a/pkg/unittest/.snapshots/TestV3RunnerOkWithFailingTemplatePassedTest
+++ b/pkg/unittest/.snapshots/TestV3RunnerOkWithFailingTemplatePassedTest
@@ -1,0 +1,14 @@
+
+### Chart [ failing-template ] ../../test/data/v3/failing-template
+
+
+ PASS  Test failing template	../../test/data/v3/failing-template/tests/configMap_test.yaml
+
+
+Charts:      1 passed, 1 total
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshot:    0 passed, 0 total
+Time:        XX.XXXms
+
+

--- a/pkg/unittest/test_job.go
+++ b/pkg/unittest/test_job.go
@@ -66,7 +66,7 @@ func scopeValuesWithRoutes(routes []string, values map[interface{}]interface{}) 
 func parseV2RenderError(errorMessage string) (string, string) {
 	// Split the error into several groups.
 	// those groups are required to parse the correct value.
-	const regexPattern string = "^.+\"(.+)\":(.+:)* (.+)$"
+	const regexPattern string = "^.+\"(.+)\":(?:.+:)* (.+)$"
 
 	filePath, content := parseRenderError(regexPattern, errorMessage)
 
@@ -76,7 +76,8 @@ func parseV2RenderError(errorMessage string) (string, string) {
 func parseV3RenderError(errorMessage string) (string, string) {
 	// Split the error into several groups.
 	// those groups are required to parse the correct value.
-	const regexPattern string = "^.+\\((.+):\\d+:\\d+\\):(.+:)* (.+)$"
+	// ^.+( |\()(.+):\d+:\d+\)?:(.+:)* (.+)$
+	const regexPattern string = "^.+(?: |\\()(.+):\\d+:\\d+\\)?:(?:.+:)* (.+)$"
 
 	filePath, content := parseRenderError(regexPattern, errorMessage)
 
@@ -90,9 +91,9 @@ func parseRenderError(regexPattern, errorMessage string) (string, string) {
 	r := regexp.MustCompile(regexPattern)
 	result := r.FindStringSubmatch(errorMessage)
 
-	if len(result) == 4 {
+	if len(result) == 3 {
 		filePath = result[1]
-		content = fmt.Sprintf("%s: %s", common.RAW, result[3])
+		content = fmt.Sprintf("%s: %s", common.RAW, result[2])
 	}
 
 	return filePath, content

--- a/pkg/unittest/test_job_test.go
+++ b/pkg/unittest/test_job_test.go
@@ -783,3 +783,25 @@ asserts:
 	a.True(testResult.Passed)
 	a.Equal(2, len(testResult.AssertsResult))
 }
+
+func TestV3RunJobWithFailingTempalte(t *testing.T) {
+	c, _ := loader.Load(testV3WithFailingTemplateChart)
+	manifest := `
+it: should work
+template: configMap.yaml
+asserts:
+  - failedTemplate:
+      errorMessage: no template "non-existing-named-template" associated with template "gotpl"
+`
+	var tj TestJob
+	yaml.Unmarshal([]byte(manifest), &tj)
+
+	testResult := tj.RunV3(c, &snapshot.Cache{}, true, &results.TestJobResult{})
+
+	a := assert.New(t)
+	cupaloy.SnapshotT(t, makeTestJobResultSnapshotable(testResult))
+
+	a.Nil(testResult.ExecError)
+	a.True(testResult.Passed)
+	a.Equal(1, len(testResult.AssertsResult))
+}

--- a/pkg/unittest/test_suite_test.go
+++ b/pkg/unittest/test_suite_test.go
@@ -31,6 +31,7 @@ const testV3BasicChart string = "../../test/data/v3/basic"
 const testV3WithSubChart string = "../../test/data/v3/with-subchart"
 const testV3WithSubFolderChart string = "../../test/data/v3/with-subfolder"
 const testV3WithSubSubFolderChart string = "../../test/data/v3/with-subsubcharts"
+const testV3WithFailingTemplateChart string = "../../test/data/v3/failing-template"
 
 var tmpdir, _ = ioutil.TempDir("", testSuiteTests)
 

--- a/test/data/v3/failing-template/Chart.yaml
+++ b/test/data/v3/failing-template/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: failing-template
+description: Test failed template assert
+type: application
+version: 0.1.0

--- a/test/data/v3/failing-template/templates/configMap.yaml
+++ b/test/data/v3/failing-template/templates/configMap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+data:
+  my-file.yaml: |
+    {{- include "non-existing-named-template" . | nindent 4 }}

--- a/test/data/v3/failing-template/tests/configMap_test.yaml
+++ b/test/data/v3/failing-template/tests/configMap_test.yaml
@@ -1,0 +1,8 @@
+suite: Test failing template
+templates:
+  - configMap.yaml
+tests:
+  - it: template should be failing
+    asserts:
+      - failedTemplate:
+          errorMessage: no template "non-existing-named-template" associated with template "gotpl"


### PR DESCRIPTION
Fixes #144

Changes:

* Add tests to test templating failures in V3 examples
* Fix error message parsing for Helm v3
* Add non-capturing openings like (?: ) so they aren't counted as
subgroups
* Simplify the execution time removal in makeOutputSnapshotable