### PR TITLE
fix: switch from `bash` to `sh` to support alpine

### DIFF
--- a/install-binary.sh
+++ b/install-binary.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # borrowed from https://github.com/technosophos/helm-template
 


### PR DESCRIPTION
I am using a minimized alpine image and currently it is not possible to install the `unittest` plugin as it is relying on **bash**

```
#7 5.962 env: can't execute 'bash': No such file or directory
#7 5.963 Error: plugin install hook for "unittest" exited with error
```
I do not want to install extra packages such as `bash` as I have to configure internal repositories mirrors .. etc

The purpose of this PR is to switch to the always available `sh`. We could add a more sophisticated check for existing shells but I believe there is no real need as the current script runs fine under '*sh*'
