### PR TITLE
Fix typo and associated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you are ready for writing tests, check the [DOCUMENT](./DOCUMENT.md) for the 
   - [Flags](#flags)
 - [Example](#example)
 - [Snapshot Testing](#snapshot-testing)
-- [Dependend subchart Testing](#dependend-subchart-testing)
+- [Dependent subchart Testing](#dependent-subchart-testing)
 - [Tests within subchart](#tests-within-subchart)
 - [test suite code completion and validation](#test-suite-code-completion-and-validation)
 - [Frequently Asked Questions](#frequently-asked-questions)


### PR DESCRIPTION
This PR intend to fix the link for `Dependent subchart Testing` in the README.md