### PR TITLE
Fix release.upgrade field documentation

### DIFF
--- a/DOCUMENT.md
+++ b/DOCUMENT.md
@@ -21,7 +21,7 @@ release:
   name: my-release
   namespace: my-namespace
   revision: 1
-  isUpgrade: true
+  upgrade: true
 capabilities:
   majorVersion: 1
   minorVersion: 10
@@ -43,7 +43,7 @@ tests:
   - **name**: *string, optional*. The release name, default to `"RELEASE-NAME"`.
   - **namespace**: *string, optional*. The namespace which release be installed to, default to `"NAMESPACE"`.
   - **revision**: *string, optional*. The revision of current build, default to `0`.
-  - **isUpgrade**: *bool, optional*. Whether the build is an upgrade, default to `false`.
+  - **upgrade**: *bool, optional*. Whether the build is an upgrade, default to `false`.
 
 - **capabilities**: *object, optional*. Define the `{{ .Capabilities }}` object.
   - **majorVersion**: *string, optional*. The kubernetes major version, default to the major version which is set by helm.
@@ -77,7 +77,7 @@ tests:
       name: my-release
       namespace:
       revision: 9
-      isUpgrade: true
+      upgrade: true
     capabilities:
       majorVersion: 1
       minorVersion: 12
@@ -106,7 +106,7 @@ tests:
   - **name**: *string, optional*. The release name, default to `"RELEASE-NAME"`.
   - **namespace**: *string, optional*. The namespace which release be installed to, default to `"NAMESPACE"`.
   - **revision**: *string, optional*. The revision of current build, default to `0`.
-  - **isUpgrade**: *bool, optional*. Whether the build is an upgrade, default to `false`.
+  - **upgrade**: *bool, optional*. Whether the build is an upgrade, default to `false`.
 
 - **capabilities**: *object, optional*. Define the `{{ .Capabilities }}` object.
   - **majorVersion**: *string, optional*. The kubernetes major version, default to the major version which is set by helm.

--- a/schema/helm-testsuite.json
+++ b/schema/helm-testsuite.json
@@ -648,10 +648,10 @@
           "description": "The revision of current build, default to 0.",
           "markdownDescription": "**revision** (string) _optional_\n\nThe revision of current build, default to `0`."
         },
-        "isUpgrade": {
+        "upgrade": {
           "type": "boolean",
           "description": "Whether the build is an upgrade, default to false.",
-          "markdownDescription": "**isUpgrade** (boolean) _optional_\n\nWhether the build is an upgrade, default to `false`."
+          "markdownDescription": "**upgrade** (boolean) _optional_\n\nWhether the build is an upgrade, default to `false`."
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
This PR fixes documentation about the `upgrade` field.

When YAML is unmarshalled the struct field `IsUpgrade` is populated from `upgrade` and not `isUpgrade`.

https://github.com/quintush/helm-unittest/blob/e1bd6f00e3e2a06fcd1db12cb342d9158144dc5e/pkg/unittest/test_suite.go#L52-L57