### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ defined in test suite files.
       --strict                 strict parse the testsuites (default false)
   -v, --values stringArray     absolute or glob paths of values files location, default no values files
   -f, --file stringArray       glob paths of test files location, default to tests\*_test.yaml (default [tests\*_test.yaml])
-  -3, --helm3                  parse helm charts as helm3 charts (default false)
   -q, --failfast               direct quit testing, when a test is failed (default false)
   -h, --help                   help for unittest
   -t, --output-type string     the file-format where testresults are written in, accepted types are (JUnit, NUnit, XUnit) (default XUnit)


### PR DESCRIPTION
No such flag in 0.3.1
```
$ helm unittest --helm3 
Error: unknown flag: --helm3
Usage:
  unittest [flags] CHART [...]

Flags:
      --color                  enforce printing colored output even stdout is not a tty. Set to false to disable color
  -d, --debug                  enable debug logging
  -q, --failfast               direct quit testing, when a test is failed
  -f, --file stringArray       glob paths of test files location, default to tests/*_test.yaml (default [tests/*_test.yaml])
  -h, --help                   help for unittest
  -o, --output-file string     output-file the file where testresults are written in JUnit format, defaults no output is written to file
  -t, --output-type string     output-type the file-format where testresults are written in, accepted types are (JUnit, NUnit, XUnit) (default "XUnit")
      --strict                 strict parse the testsuites
  -u, --update-snapshot        update the snapshot cached if needed, make sure you review the change before update
  -v, --values stringArray     absolute or glob paths of values files location, default no values files
  -s, --with-subchart charts   include tests of the subcharts within charts folder (default true)

unknown flag: --helm3
Error: plugin "unittest" exited with error
```